### PR TITLE
ci: bump deploy actions off deprecated Node 20

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Build Astro site
-        uses: withastro/action@v3
+        uses: withastro/action@v6
         with:
           node-version: 22
 
@@ -35,4 +35,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

- Bumps GitHub Actions to clear the Node 20 runtime deprecation warning (Node 20 forced off runners 2026-06-02):
  - `actions/checkout` v4 → v6
  - `withastro/action` v3 → v6 (pulls in Node 24-based internal `setup-node`/`upload-artifact`)
  - `actions/deploy-pages` v4 → v5
- `withastro/action@v6` retains the `node-version` input, so the build config is unchanged.

## Test plan

- [ ] Deploy workflow runs green on merge to master
- [ ] No Node 20 deprecation annotation on the run
- [ ] https://wes-chen.github.io/ and /about/ still serve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)