### PR TITLE
feat: human authorship disclaimer + blog content guardrails

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,12 @@ public/
 
 **`tilePerHalf * 2` must be even.** The CSS animation uses `translateX(-50%)` on a track that is two identical halves; an odd span count breaks the seamless loop.
 
+## Blog post authorship — hard rule
+
+**Claude must never write blog post prose.** All content in `src/pages/blog/*.md` must come from Wesley. Claude's role is limited to site infrastructure: layouts, styles, components, config, CI. If asked to write or draft a blog post, refuse and explain this constraint.
+
+Wesley writes posts as plain markdown files and PRs them in without Claude involvement. Do not add co-authorship attribution to commits that only contain `.md` files in `src/pages/blog/`.
+
 ## Adding a blog post
 
 Create `src/pages/blog/<slug>.md` with this frontmatter:

--- a/public/style.css
+++ b/public/style.css
@@ -108,6 +108,13 @@ ul.post-list time {
   color: var(--muted);
 }
 
+.human-note {
+  margin-top: 2rem;
+  font-size: 0.8125rem;
+  color: var(--muted);
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
 /* ── Post page ────────────────────────── */
 
 article .post-header {

--- a/src/pages/blog/hello-world.md
+++ b/src/pages/blog/hello-world.md
@@ -3,7 +3,7 @@ layout: ../../layouts/Post.astro
 title: Hello World
 date: 2026-05-24
 description: Why I'm starting to write.
-draft: false
+draft: true
 ---
 
 I've been meaning to start a blog for a few years. The usual excuses applied: not enough time, nothing interesting enough to say, someone smarter has already written about this.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -25,4 +25,5 @@ const sorted = posts
       })}
     </ul>
   )}
+  <p class="human-note">All writing is my own — no AI-generated content.</p>
 </Base>


### PR DESCRIPTION
## Summary
- Adds "All writing is my own — no AI-generated content." note to the homepage below the post list
- Drafts the AI-written hello-world post so it no longer appears publicly
- Adds a hard rule to CLAUDE.md prohibiting Claude from writing blog post prose

## Test plan
- [ ] Homepage shows the authorship disclaimer below the post list
- [ ] hello-world post no longer appears in the index
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)