### PR TITLE
Fix post date rendering + site-wide dark theme

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -3,10 +3,12 @@
 }
 
 :root {
-  --bg: #faf9f7;
-  --text: #1a1917;
-  --muted: #6b6760;
-  --link: #1a1917;
+  --bg: #050504;
+  --text: #f5f3ef;
+  --muted: #8c877d;
+  --link: #f5f3ef;
+  --border: rgba(245, 243, 239, 0.14);
+  --code-bg: #24292e;
   --max-w: 680px;
 }
 
@@ -30,7 +32,7 @@ header {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  border-bottom: 1px solid #e5e2dc;
+  border-bottom: 1px solid var(--border);
 }
 
 .site-name {
@@ -81,11 +83,11 @@ ul.post-list li {
   align-items: baseline;
   gap: 1rem;
   padding: 0.6rem 0;
-  border-bottom: 1px solid #e5e2dc;
+  border-bottom: 1px solid var(--border);
 }
 
 ul.post-list li:first-child {
-  border-top: 1px solid #e5e2dc;
+  border-top: 1px solid var(--border);
 }
 
 ul.post-list a {
@@ -136,7 +138,7 @@ h1 {
 h2 {
   font-size: 1.1rem;
   margin: 2.5rem 0 1rem;
-  border-bottom: 1px solid #e5e2dc;
+  border-bottom: 1px solid var(--border);
   padding-bottom: 0.4rem;
 }
 
@@ -168,7 +170,7 @@ p {
 }
 
 .prose pre {
-  background: #f0ede8;
+  background: var(--code-bg);
   padding: 1rem;
   overflow-x: auto;
   border-radius: 4px;
@@ -177,7 +179,7 @@ p {
 
 .prose code {
   font-size: 0.875rem;
-  background: #f0ede8;
+  background: var(--code-bg);
   padding: 0.1em 0.3em;
   border-radius: 3px;
 }
@@ -188,7 +190,7 @@ p {
 }
 
 .prose blockquote {
-  border-left: 3px solid #c9c4bc;
+  border-left: 3px solid var(--muted);
   margin: 1.5rem 0;
   padding-left: 1rem;
   color: var(--muted);

--- a/src/layouts/Post.astro
+++ b/src/layouts/Post.astro
@@ -4,8 +4,8 @@ import Base from './Base.astro';
 const { frontmatter } = Astro.props;
 const { title, date, description } = frontmatter;
 
-const formatted = new Date(date + 'T12:00:00').toLocaleDateString('en-US', {
-  year: 'numeric', month: 'long', day: 'numeric'
+const formatted = new Date(date).toLocaleDateString('en-US', {
+  year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC'
 });
 ---
 <Base title={title} description={description}>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,8 +13,8 @@ const sorted = posts
   ) : (
     <ul class="post-list">
       {sorted.map(post => {
-        const formatted = new Date(post.frontmatter.date + 'T12:00:00').toLocaleDateString('en-US', {
-          year: 'numeric', month: 'short', day: 'numeric'
+        const formatted = new Date(post.frontmatter.date).toLocaleDateString('en-US', {
+          year: 'numeric', month: 'short', day: 'numeric', timeZone: 'UTC'
         });
         return (
           <li>


### PR DESCRIPTION
## Summary
- **Fix "Invalid Date":** `Post.astro` and `index.astro` treated the YAML `date` (parsed as a Date object) as a string via `date + 'T12:00:00'`, producing **"Invalid Date"** on every post and the homepage list — including the already-live `hello-world` post. Now formatted directly in UTC so the shown day matches the frontmatter regardless of server timezone.
- **Dark theme by default:** flipped the `:root` palette to the dark values the homepage already used (`#050504` / `#f5f3ef`) so posts and the About page match the front door. Added `--border` / `--code-bg` tokens and converted the remaining hardcoded light colors (hairlines, code background, blockquote rule). The homepage (`body.front`) is unchanged.

## Test plan
- [x] `npm run build` passes locally (3 pages built)
- [x] Post + homepage dates render real dates ("May 24, 2026", was "Invalid Date")
- [ ] Posts + About render dark (black bg, off-white text) — eyeball in browser
- [ ] Homepage wordmark + animation unchanged
- [ ] Shiki `github-dark` code blocks legible on the dark background

🤖 Generated with [Claude Code](https://claude.com/claude-code)