### PR TITLE
fix: wrap long lines in code blocks (#22)

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -179,9 +179,18 @@ p {
 .prose pre {
   background: var(--code-bg);
   padding: 1rem;
-  overflow-x: auto;
   border-radius: 4px;
   font-size: 0.875rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* Shiki emits overflow-x:auto as an inline style; override it so long lines wrap */
+.astro-code,
+.astro-code code {
+  overflow-x: visible !important;
+  white-space: pre-wrap !important;
+  word-break: break-word;
 }
 
 .prose code {


### PR DESCRIPTION
## Summary

- Removes `overflow-x: auto` from `.prose pre` and replaces it with `white-space: pre-wrap` + `word-break: break-word`
- Adds `.astro-code, .astro-code code` rules with `overflow-x: visible !important` and `white-space: pre-wrap !important` to override Shiki's inline `style="overflow-x: auto"` (which a plain class selector can't beat)

Closes #22

## Test plan

- [ ] Open `/blog/learning-with-ai` at mobile width (~375px) — the long prompt block wraps with no horizontal scrollbar
- [ ] Indentation in the block is still readable (pre-wrap preserves leading whitespace)
- [ ] Other code blocks across the site look unaffected
- [ ] `npm run build` exits clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)