### PR TITLE
feat: show post description as subtitle under title

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -129,6 +129,13 @@ article h1 {
   margin: 0 0 0.4rem;
 }
 
+article .post-subtitle {
+  margin: 0.25rem 0 0.6rem;
+  font-size: 1rem;
+  font-style: italic;
+  color: #b8b3ac;
+}
+
 article .post-header time {
   font-size: 0.875rem;
   color: var(--muted);

--- a/src/layouts/Post.astro
+++ b/src/layouts/Post.astro
@@ -12,6 +12,7 @@ const formatted = new Date(date).toLocaleDateString('en-US', {
   <article>
     <header class="post-header">
       <h1>{title}</h1>
+      {description && <p class="post-subtitle">{description}</p>}
       <time datetime={date}>{formatted}</time>
     </header>
     <div class="prose">


### PR DESCRIPTION
## Summary

- Renders each post's frontmatter `description` as `<p class="post-subtitle">` between the `<h1>` and the date in `.post-header`, only when the field is present
- Styled italic at `#b8b3ac` — between `--text` and `--muted` — with tight top margin (`0.25rem`) and comfortable gap before the date (`0.6rem`)
- `<meta name="description">` is unchanged

Closes #23

## Test plan

- [ ] Visit `/blog/learning-with-ai` — subtitle *"Ew, AI. Yes. But how do we exploit it?"* appears italic under the title, above the date
- [ ] Inspect `<head>` — `<meta name="description">` still present
- [ ] Visit a post with no description (if one exists) — no extra element rendered, no visual gap
- [ ] `npm run build` completes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)