### PR TITLE
fix: deduplicate date logic + emit YYYY-MM-DD datetime attrs

### DIFF
--- a/src/layouts/Post.astro
+++ b/src/layouts/Post.astro
@@ -1,19 +1,19 @@
 ---
 import Base from './Base.astro';
+import { formatDateDisplay, formatDateAttr } from '../lib/date';
 
 const { frontmatter } = Astro.props;
 const { title, date, description } = frontmatter;
 
-const formatted = new Date(date).toLocaleDateString('en-US', {
-  year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC'
-});
+const formatted = formatDateDisplay(date, 'long');
+const dateAttr = formatDateAttr(date);
 ---
 <Base title={title} description={description}>
   <article>
     <header class="post-header">
       <h1>{title}</h1>
       {description && <p class="post-subtitle">{description}</p>}
-      <time datetime={date}>{formatted}</time>
+      <time datetime={dateAttr}>{formatted}</time>
     </header>
     <div class="prose">
       <slot />

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,0 +1,16 @@
+export function formatDateDisplay(date: Date | string, format: 'long' | 'short'): string {
+  return new Date(date).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: format === 'long' ? 'long' : 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+}
+
+export function formatDateAttr(date: Date | string): string {
+  const d = new Date(date);
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import Base from '../layouts/Base.astro';
+import { formatDateDisplay, formatDateAttr } from '../lib/date';
 
 const allPosts = import.meta.glob('./blog/*.md', { eager: true });
 const posts = Object.values(allPosts) as any[];
@@ -13,13 +14,12 @@ const sorted = posts
   ) : (
     <ul class="post-list">
       {sorted.map(post => {
-        const formatted = new Date(post.frontmatter.date).toLocaleDateString('en-US', {
-          year: 'numeric', month: 'short', day: 'numeric', timeZone: 'UTC'
-        });
+        const formatted = formatDateDisplay(post.frontmatter.date, 'short');
+        const dateAttr = formatDateAttr(post.frontmatter.date);
         return (
           <li>
             <a href={post.url}>{post.frontmatter.title}</a>
-            <time datetime={post.frontmatter.date}>{formatted}</time>
+            <time datetime={dateAttr}>{formatted}</time>
           </li>
         );
       })}


### PR DESCRIPTION
## Summary

- Extracts date formatting into `src/lib/date.ts` (`formatDateDisplay` / `formatDateAttr`), eliminating the duplicated `toLocaleDateString` calls in `Post.astro` and `index.astro`
- Fixes `<time datetime>` emitting the full ISO-8601 timestamp (e.g. `2026-05-25T00:00:00.000Z`) instead of `YYYY-MM-DD` — Astro parses YAML dates as JS `Date` objects, which stringified to the full timestamp
- Display formats are unchanged: long "Month D, YYYY" on post pages, short on the index list

Closes #21.

## Test plan

- [x] `npm run build` completes with 0 errors
- [x] Built HTML `datetime` attrs confirmed `YYYY-MM-DD` (e.g. `2026-05-24`, `2026-05-25`) via grep on dist output
- [ ] `npm run dev` — verify dates render correctly on both index (dark theme) and individual post pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)