### PR TITLE
feat: separate content license + AI-crawler directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,4 +81,6 @@ Pushes to `master` trigger the [GitHub Pages workflow](.github/workflows/deploy.
 
 ## License
 
-[MIT](LICENSE)
+Source code is [MIT](LICENSE).
+
+Writing in `src/pages/blog/` is © Wesley Chen, all rights reserved — not covered by the MIT license.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,24 @@
+User-agent: *
+Allow: /
+
+# AI crawlers — writing is © Wesley Chen, all rights reserved
+User-agent: GPTBot
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: PerplexityBot
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /

--- a/public/style.css
+++ b/public/style.css
@@ -69,6 +69,21 @@ main {
   padding: 2.5rem 0 4rem;
 }
 
+/* ── Footer ───────────────────────────── */
+
+footer {
+  max-width: var(--max-w);
+  margin: 0 auto;
+  padding: 1.5rem 0 2rem;
+  border-top: 1px solid var(--border);
+}
+
+footer p {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
 /* ── Post list (index) ────────────────── */
 
 ul.post-list {
@@ -233,9 +248,19 @@ body.front {
 }
 
 body.front header,
-body.front main {
+body.front main,
+body.front footer {
   position: relative;
   z-index: 1;
+}
+
+body.front footer {
+  border-top-color: rgba(245, 243, 239, 0.14);
+  color: #8c877d;
+}
+
+body.front footer a {
+  color: #8c877d;
 }
 
 body.front .site-name,

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -13,6 +13,7 @@ const pageTitle = title ? `${title} — Wesley Chen` : 'Wesley Chen';
   <link rel="icon" href="/favicon.ico" />
   {front && <link rel="preload" href="/fonts/syne-wall.woff2" as="font" type="font/woff2" crossorigin />}
   <link rel="stylesheet" href="/style.css" />
+  <meta name="robots" content="noai, noimage" />
   <script type="application/ld+json" set:html={JSON.stringify({
     "@context": "https://schema.org",
     "@type": "Person",
@@ -33,5 +34,8 @@ const pageTitle = title ? `${title} — Wesley Chen` : 'Wesley Chen';
   <main>
     <slot />
   </main>
+  <footer>
+    <p>Source code is <a href="https://github.com/wes-chen/wes-chen.github.io/blob/master/LICENSE">MIT</a>. Writing is &copy; Wesley Chen, all rights reserved.</p>
+  </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- **Content license carve-out**: README and site footer now explicitly state that source code is MIT but writing in `src/pages/blog/` is © Wesley Chen, all rights reserved. The MIT LICENSE was unintentionally covering blog prose.
- **`public/robots.txt`**: Disallows GPTBot, CCBot, Google-Extended, ClaudeBot, anthropic-ai, PerplexityBot, and Bytespider from crawling the site. General search crawlers remain allowed.
- **`<meta name="robots" content="noai, noimage">`**: Added to `Base.astro` so every page signals no AI training use.
- **Footer**: Added a styled site footer with the license notice; dark front-page theme overrides included.

No conflict with `feat/human-authorship-disclaimer` — that branch was already merged as #17.

## Test plan

- [x] `npm run build` passes cleanly (4 pages built)
- [x] `dist/robots.txt` present and correct in build output
- [ ] Footer renders on both light (post/about) and dark (homepage) pages
- [ ] `<meta name="robots" content="noai, noimage">` present in page source

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)