### PR TITLE
feat: add GoatCounter analytics

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -14,6 +14,7 @@ const pageTitle = title ? `${title} — Wesley Chen` : 'Wesley Chen';
   {front && <link rel="preload" href="/fonts/syne-wall.woff2" as="font" type="font/woff2" crossorigin />}
   <link rel="stylesheet" href="/style.css" />
   <meta name="robots" content="noai, noimage" />
+  <script data-goatcounter="https://wes-chen.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
   <script type="application/ld+json" set:html={JSON.stringify({
     "@context": "https://schema.org",
     "@type": "Person",


### PR DESCRIPTION
## Summary

- Relaxes the no-external-CDN rule for one small, trusted analytics snippet (decision made per issue discussion)
- Adds `<script data-goatcounter="https://wes-chen.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>` to `Base.astro` `<head>` — covers every page with a single insertion
- GoatCounter: cookieless, ~3KB, open-source. No consent banner required.

## Test plan

- [x] `npm run build` passes cleanly (4 pages built)
- [x] Script tag present in all built HTML files (`dist/`)
- [x] `async` attribute ensures no layout shift or render blocking

Closes #19