### PR TITLE
fix: stack post subtitle below title on mobile

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -135,6 +135,7 @@ ul.post-list time {
 /* ── Post page ────────────────────────── */
 
 article .post-header {
+  display: block;
   margin-bottom: 2rem;
 }
 


### PR DESCRIPTION
## Summary

- The global `header` CSS selector sets `display: flex; justify-content: space-between`, which was inadvertently applied to `.post-header` inside blog posts
- This cramped the title, subtitle, and date into a horizontal row on mobile
- Fix: add `display: block` to `article .post-header` to override the inherited flex layout and restore vertical stacking

## Test plan
- [ ] Open a blog post on mobile (or narrow the browser window) — title, subtitle, and date should stack vertically, not side-by-side
- [ ] Desktop layout looks unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)