### PR TITLE
fix: restore favicon (SVG primary, PNG fallback)

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -10,7 +10,8 @@ const pageTitle = title ? `${title} — Wesley Chen` : 'Wesley Chen';
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{pageTitle}</title>
   <meta name="description" content={description || "Wesley Chen — Software Engineer at Snap Inc."} />
-  <link rel="icon" href="/favicon.ico" />
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+  <link rel="icon" href="/favicon.ico" type="image/png" />
   <link rel="preload" href="/fonts/vollkorn-400-700-latin.woff2" as="font" type="font/woff2" crossorigin />
   {front && <link rel="preload" href="/fonts/syne-wall.woff2" as="font" type="font/woff2" crossorigin />}
   <link rel="stylesheet" href="/style.css" />


### PR DESCRIPTION
## Summary

- `favicon.ico` was a PNG file in disguise — renamed/typed correctly as `image/png`
- `favicon.svg` (which includes `prefers-color-scheme` dark-mode adaptation) was never linked — now referenced as the primary icon
- Modern browsers use the SVG; older ones fall back to the PNG

## Test plan

- [ ] Load site in Chrome/Firefox/Safari — tab shows icon
- [ ] Switch OS to dark mode — icon inverts to white