### PR TITLE
docs: document GoatCounter exception to no-external-calls rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,8 @@ public/
 
 ## Key constraints
 
+**Self-host all assets; avoid runtime external/CDN calls.** One intentional exception: GoatCounter analytics (`gc.zgo.at`) loads `//gc.zgo.at/count.js` at runtime for basic privacy-friendly page metrics (#19 / #29). Do not remove it as a "fix."
+
 **Font subset — do not change the wordmark phrase without re-subsetting.**
 `public/fonts/syne-wall.woff2` is subset to exactly the glyphs in `"Wesley Chen"`. The phrase is defined in `src/components/TileWall.astro` (`tilePhrase`). If you change that string, letters outside the subset will silently fall back to system fonts.
 


### PR DESCRIPTION
## Summary

- Adds a note to the **Key constraints** section of `CLAUDE.md` that the site self-hosts all assets and avoids runtime external/CDN calls
- Documents GoatCounter (`gc.zgo.at`) as the one intentional exception, pointing to the issues where it was introduced (#19 / #29)
- Includes a guard ("do not remove it as a fix") so future sessions don't strip it out

No code changes.

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)