### PR TITLE
feat: SEO meta, RSS feed, and sitemap

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,4 +2,6 @@
 import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
-export default defineConfig({});
+export default defineConfig({
+  site: 'https://wes-chen.github.io',
+});

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,6 +1,8 @@
 User-agent: *
 Allow: /
 
+Sitemap: https://wes-chen.github.io/sitemap.xml
+
 # AI crawlers — writing is © Wesley Chen, all rights reserved
 User-agent: GPTBot
 Disallow: /

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,15 +1,28 @@
 ---
 import TileWall from '../components/TileWall.astro';
 
-const { title, description, front = false } = Astro.props;
+const { title, description, front = false, ogType = 'website' } = Astro.props;
 const pageTitle = title ? `${title} — Wesley Chen` : 'Wesley Chen';
+const pageDescription = description || "Wesley Chen — Software Engineer at Snap Inc.";
+const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 ---
 <html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{pageTitle}</title>
-  <meta name="description" content={description || "Wesley Chen — Software Engineer at Snap Inc."} />
+  <meta name="description" content={pageDescription} />
+  <link rel="canonical" href={canonicalURL} />
+  <meta property="og:title" content={pageTitle} />
+  <meta property="og:description" content={pageDescription} />
+  <meta property="og:type" content={ogType} />
+  <meta property="og:url" content={canonicalURL} />
+  <meta property="og:site_name" content="Wesley Chen" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content={pageTitle} />
+  <meta name="twitter:description" content={pageDescription} />
+  <meta name="theme-color" content="#050504" />
+  <link rel="alternate" type="application/rss+xml" title="Wesley Chen" href="/rss.xml" />
   <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
   <link rel="icon" href="/favicon.ico" type="image/png" />
   <link rel="preload" href="/fonts/vollkorn-400-700-latin.woff2" as="font" type="font/woff2" crossorigin />

--- a/src/layouts/Post.astro
+++ b/src/layouts/Post.astro
@@ -8,7 +8,7 @@ const { title, date, description } = frontmatter;
 const formatted = formatDateDisplay(date, 'long');
 const dateAttr = formatDateAttr(date);
 ---
-<Base title={title} description={description}>
+<Base title={title} description={description} ogType="article">
   <article>
     <header class="post-header">
       <h1>{title}</h1>

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,0 +1,39 @@
+import type { APIRoute } from 'astro';
+
+export const GET: APIRoute = async ({ site }) => {
+  const allPosts = import.meta.glob('./blog/*.md', { eager: true }) as Record<string, any>;
+  const posts = Object.values(allPosts)
+    .filter(p => !p.frontmatter.draft)
+    .sort((a, b) => new Date(b.frontmatter.date).getTime() - new Date(a.frontmatter.date).getTime());
+
+  const feedUrl = new URL('/rss.xml', site);
+
+  const items = posts.map(post => {
+    const url = new URL(post.url, site);
+    const pubDate = new Date(post.frontmatter.date).toUTCString();
+    const desc = post.frontmatter.description ?? '';
+    return `    <item>
+      <title><![CDATA[${post.frontmatter.title}]]></title>
+      <description><![CDATA[${desc}]]></description>
+      <link>${url}</link>
+      <guid>${url}</guid>
+      <pubDate>${pubDate}</pubDate>
+    </item>`;
+  }).join('\n');
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Wesley Chen</title>
+    <description>Wesley Chen's writing</description>
+    <link>${site}</link>
+    <atom:link href="${feedUrl}" rel="self" type="application/rss+xml" />
+    <language>en-us</language>
+${items}
+  </channel>
+</rss>`;
+
+  return new Response(xml, {
+    headers: { 'Content-Type': 'application/rss+xml; charset=utf-8' },
+  });
+};

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -1,0 +1,22 @@
+import type { APIRoute } from 'astro';
+
+export const GET: APIRoute = async ({ site }) => {
+  const allPosts = import.meta.glob('./blog/*.md', { eager: true }) as Record<string, any>;
+  const publishedPosts = Object.values(allPosts).filter(p => !p.frontmatter.draft);
+
+  const staticPaths = ['/', '/about'];
+  const postPaths = publishedPosts.map(p => p.url as string);
+
+  const entries = [...staticPaths, ...postPaths]
+    .map(path => `  <url><loc>${new URL(path, site)}</loc></url>`)
+    .join('\n');
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${entries}
+</urlset>`;
+
+  return new Response(xml, {
+    headers: { 'Content-Type': 'application/xml; charset=utf-8' },
+  });
+};


### PR DESCRIPTION
## Summary

- Sets `site: 'https://wes-chen.github.io'` in `astro.config.mjs` (shared prerequisite for all three issues)
- **#31** — `Base.astro` now emits `og:title/description/type/url/site_name`, `twitter:card/title/description`, `<link rel="canonical">`, `<meta name="theme-color" content="#050504">`, and `<link rel="alternate" rss>`. Posts pass `ogType="article"`; all other pages default to `"website"`.
- **#32** — Hand-rolled RSS 2.0 feed at `/rss.xml` (zero new deps). Globs `./blog/*.md`, filters drafts, sorts by date desc, emits absolute URLs. `atom:link` self-reference included for validators.
- **#33** — Hand-rolled sitemap at `/sitemap.xml` (zero new deps). Lists home, `/about`, and published posts with absolute URLs. `public/robots.txt` gets `Sitemap: https://wes-chen.github.io/sitemap.xml`.

## Test plan

- [x] `npm run build` is green (4 pages + `/rss.xml` + `/sitemap.xml` emitted)
- [x] `/rss.xml` has absolute URLs, excludes `hello-world` (draft), sorted newest-first
- [x] `/sitemap.xml` has absolute URLs for `/`, `/about`, `/blog/learning-with-ai`; excludes draft post
- [x] `view-source` on a post shows `og:type=article`, correct canonical, description, theme-color
- [x] `view-source` on homepage shows `og:type=website`, RSS autodiscovery link

Closes #31
Closes #32
Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)